### PR TITLE
docs: images architecture, options pages, and Loco Translate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,6 +301,24 @@ patternlab/source/css/
 2. Co-located `.scss` files are processed by PatternLab
 3. Compiled CSS is copied to theme during build
 
+### Images Architecture
+
+**IMPORTANT**: Images are merged from TWO sources during build. To avoid duplication, follow these rules:
+
+**Image sources** (both are copied to `/build/.../images/`):
+- `/patternlab/source/images/` - PatternLab images (icons, UI assets)
+- `/src/theme/assets/images/` - WordPress-specific images
+
+**Rules to avoid duplication**:
+- **Icons and UI assets**: Add ONLY in `/patternlab/source/images/icons/`
+- **WordPress-specific images** (admin, backend): Add in `/src/theme/assets/images/`
+- **NEVER duplicate** the same image in both directories
+
+**Build flow for images**:
+1. Gulp reads from both `/patternlab/source/images/` and `/src/theme/assets/images/`
+2. Both are merged into `/build/wp-content/themes/{theme}/images/`
+3. If same filename exists in both, one will overwrite the other
+
 ### What You Can Touch
 
 **✅ Always safe to create/modify**:
@@ -309,6 +327,7 @@ patternlab/source/css/
 - ACF blocks in `/src/theme/blocks/{block-name}/` (JSON, PHP, Twig in same directory)
 - PatternLab patterns in `/patternlab/source/_patterns/` (atoms, molecules, organisms, templates)
 - PatternLab styles in `/patternlab/source/css/scss/` (ALL frontend styles)
+- PatternLab images in `/patternlab/source/images/` (icons, UI assets)
 - WordPress page templates in `/src/theme/views/pages/`
 - WordPress layouts in `/src/theme/views/layouts/`
 - WordPress components in `/src/theme/views/components/`

--- a/docs/COMMON-TASKS.md
+++ b/docs/COMMON-TASKS.md
@@ -18,6 +18,7 @@ Step-by-step guides for common development tasks in Talampaya.
     - [Adding a Menu Location](#adding-a-menu-location)
     - [Adding a Sidebar](#adding-a-sidebar)
     - [Customizing Admin](#customizing-admin)
+    - [Adding Options Pages](#adding-options-pages)
 
 ## Cleaning Scaffolding (For Forks)
 
@@ -941,6 +942,118 @@ add_action('wp_dashboard_setup', function() {
     );
 });
 ```
+
+## Adding Options Pages
+
+**Time**: 10 minutes
+
+Options Pages allow you to create admin pages with ACF fields for global site settings.
+
+**Location**: `/src/theme/src/Features/Admin/Pages/`
+
+**Steps**:
+
+1. **Create Options Page class**:
+   ```php
+   <?php
+
+   declare(strict_types=1);
+
+   namespace App\Features\Admin\Pages;
+
+   use Illuminate\Support\Str;
+   use App\Inc\Helpers\AcfHelper;
+
+   class MySettingsOptionsPage
+   {
+       private string $page_slug = "my-settings";
+
+       public function __construct()
+       {
+           // Register ACF options page
+           add_action("acf/init", [$this, "registerOptionsPage"], 10);
+
+           // Register ACF fields
+           add_action("acf/init", [$this, "registerFields"], 20);
+       }
+
+       public function registerOptionsPage(): void
+       {
+           if (function_exists("acf_add_options_page")) {
+               acf_add_options_page([
+                   "page_title" => __("My Settings", "talampaya"),
+                   "menu_title" => __("My Settings", "talampaya"),
+                   "menu_slug" => $this->page_slug,
+                   "capability" => "edit_posts",
+                   "parent_slug" => "themes.php",
+                   "icon_url" => "dashicons-admin-settings",
+                   "position" => 30,
+                   "redirect" => false,
+               ]);
+           }
+       }
+
+       public function registerFields(): void
+       {
+           $block_title = __("Settings", "talampaya");
+
+           $fields = [
+               ["setting_text", "text", 100, __("Text Setting", "talampaya"), 1],
+               ["setting_toggle", "true_false", 100, __("Enable Feature", "talampaya"), 0],
+           ];
+
+           $groups = [[$block_title, AcfHelper::talampaya_create_acf_group_fields($fields), 1]];
+
+           foreach ($groups as $group) {
+               $field_group = [
+                   "key" => Str::snake($group[0]),
+                   "title" => __($group[0], "talampaya"),
+                   "fields" => $group[1],
+                   "location" => [
+                       [
+                           [
+                               "param" => "options_page",
+                               "operator" => "==",
+                               "value" => $this->page_slug,
+                           ],
+                       ],
+                   ],
+                   "show_in_rest" => true,
+                   "menu_order" => $group[2],
+               ];
+
+               acf_add_local_field_group(
+                   AcfHelper::talampaya_replace_keys_from_acf_register_fields(
+                       $field_group,
+                       "my_settings",
+                       "options"
+                   )
+               );
+           }
+       }
+   }
+
+   new MySettingsOptionsPage();
+   ```
+
+2. **Save file** - Auto-registered by WordPress
+
+3. **Access options** in your code:
+   ```php
+   $value = get_field("options_my_settings_setting_text", "option");
+   ```
+
+4. **Common parent slugs**:
+   - `"themes.php"` - Under Appearance
+   - `"options-general.php"` - Under Settings
+   - `"edit.php"` - Under Posts
+   - `null` - Top level menu item
+
+**Tips**:
+- Use `parent_slug` to group related settings
+- Set appropriate `capability` for security
+- Use descriptive `menu_slug` to avoid conflicts
+- Field names follow pattern: `options_{slug}_{field_name}`
 
 ---
 

--- a/docs/THIRD-PARTY.md
+++ b/docs/THIRD-PARTY.md
@@ -135,6 +135,87 @@ See [ACF-BLOCKS.md](ACF-BLOCKS.md) for complete documentation.
 } ?>
 ```
 
+### Loco Translate
+
+**Version**: Latest
+**Purpose**: Translation management for .po/.mo files
+
+**Installation** (via Composer):
+```json
+{
+  "require": {
+    "wpackagist-plugin/loco-translate": "*"
+  }
+}
+```
+
+**Documentation**: https://localise.biz/wordpress/plugin
+
+**Key Features**:
+- In-browser translation editor
+- Extract strings from source code
+- Compile .mo files automatically
+- Translation progress tracking
+- Backup management
+
+**Theme Translation Setup**:
+
+1. **POT File Location**: `src/theme/languages/talampaya.pot`
+   - The build system renames this to match the theme name (e.g., `my-theme.pot`) in `/build/.../languages/`
+
+2. **Create Translations**:
+   - Go to Loco Translate → Themes → [Your Theme Name]
+   - Click "New language"
+   - Select target language
+   - Start translating strings
+
+3. **File Structure** (source):
+   ```
+   src/theme/languages/
+   ├── talampaya.pot          # Template (source strings)
+   ├── talampaya-ca.po        # Catalan translations
+   ├── talampaya-ca.mo        # Compiled Catalan
+   ├── talampaya-fr_FR.po     # French translations
+   └── talampaya-fr_FR.mo     # Compiled French
+   ```
+
+   After build (renamed to theme name):
+   ```
+   build/theme/languages/
+   ├── my-theme.pot
+   ├── my-theme-ca.po
+   └── my-theme-ca.mo
+   ```
+
+4. **Adding New Translatable Strings**:
+   ```php
+   // Use 'talampaya' as text domain - it gets replaced during build
+   __('Your string', 'talampaya');
+
+   // With sprintf for dynamic content
+   sprintf(__('Welcome, %s', 'talampaya'), $username);
+   ```
+
+5. **Sync New Strings**:
+   - After adding new `__()` calls in code
+   - Go to Loco Translate → Themes → [Your Theme Name]
+   - Click "Sync" to detect new strings
+   - Or manually update the .pot file
+
+**Usage in Templates**:
+```php
+// In PHP (use 'talampaya' - replaced during build)
+echo __('Button Label', 'talampaya');
+
+// In Twig (via WordPress function)
+{{ __('Button Label', 'talampaya') }}
+```
+
+**Multisite Configuration**:
+- Each site can have its own language set in Settings → General
+- Translations are shared across the network
+- Each site loads translations based on `WPLANG` setting
+
 ### WPML
 
 **Version**: Latest


### PR DESCRIPTION
## Summary

Three independent documentation additions extracted from the `girbau-wp` fork. No behavior changes, no code touched.

- **`CLAUDE.md`** — new section **Images Architecture** explaining how `/patternlab/source/images/` and `/src/theme/assets/images/` are merged during build and the rules to avoid duplication.
- **`docs/COMMON-TASKS.md`** — new section **Adding Options Pages** with a complete, generic example of creating an ACF options page under `/src/theme/src/Features/Admin/Pages/`.
- **`docs/THIRD-PARTY.md`** — new section **Loco Translate** describing installation, theme translation setup, POT/PO/MO file structure, sync workflow, and multisite behavior.

## Test plan

- [ ] Render `CLAUDE.md` in GitHub — verify the new section renders correctly and links work.
- [ ] Render `docs/COMMON-TASKS.md` — verify the new TOC entry links to the new section.
- [ ] Render `docs/THIRD-PARTY.md` — verify code blocks render.

## Notes

Draft so you can review wording before merging. The Options Pages example uses `talampaya` as text domain (replaced during build), consistent with the existing convention in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)