### PR TITLE
feat(helpers): pagination, breadcrumb, and ACF conditional_logic fix for repeater subfields

### DIFF
--- a/src/theme/src/Inc/Helpers/AcfHelper.php
+++ b/src/theme/src/Inc/Helpers/AcfHelper.php
@@ -81,11 +81,61 @@ class AcfHelper
 						true
 					);
 					$field["sub_fields"] = $new_subfields["fields"];
+
+					// Subfields just got their keys prefixed; rewrite any
+					// conditional_logic references pointing at the original
+					// (un-prefixed) names so ACF can resolve them.
+					$field["sub_fields"] = self::updateConditionalLogicReferences(
+						$field["sub_fields"],
+						$key
+					);
 				}
 			}
 		}
 
 		return $array;
+	}
+
+	/**
+	 * Rewrite conditional_logic field references after subfield keys are prefixed.
+	 *
+	 * When a field group is rendered inside a repeater, this helper prefixes
+	 * each subfield key with the parent key. Any conditional_logic rule that
+	 * was authored against the original (un-prefixed) name would otherwise be
+	 * orphaned. This rebuilds those references so the rules keep working.
+	 *
+	 * @param array $fields Subfields after key replacement.
+	 * @param string $key Prefix that was just applied to the subfields.
+	 * @return array Subfields with conditional_logic references rewritten.
+	 */
+	private static function updateConditionalLogicReferences(array $fields, string $key): array
+	{
+		// Map original (un-prefixed) name → new prefixed key.
+		$key_map = [];
+		foreach ($fields as $field) {
+			if (isset($field["key"]) && strpos($field["key"], $key . "_") === 0) {
+				$original_without_prefix = substr($field["key"], strlen($key . "_"));
+				$key_map[$original_without_prefix] = $field["key"];
+			}
+		}
+
+		foreach ($fields as &$field) {
+			if (!isset($field["conditional_logic"]) || !is_array($field["conditional_logic"])) {
+				continue;
+			}
+			foreach ($field["conditional_logic"] as &$condition_group) {
+				if (!is_array($condition_group)) {
+					continue;
+				}
+				foreach ($condition_group as &$condition) {
+					if (isset($condition["field"], $key_map[$condition["field"]])) {
+						$condition["field"] = $key_map[$condition["field"]];
+					}
+				}
+			}
+		}
+
+		return $fields;
 	}
 
 	/**

--- a/src/theme/src/Inc/Helpers/BreadcrumbHelper.php
+++ b/src/theme/src/Inc/Helpers/BreadcrumbHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Inc\Helpers;
+
+use Timber\Timber;
+
+class BreadcrumbHelper
+{
+	/**
+	 * Generates simple breadcrumbs: Home > Current Page
+	 *
+	 * @return array Array of breadcrumb items with 'label' and optional 'url'
+	 */
+	public static function generateBreadcrumbs(): array
+	{
+		$breadcrumbs = [["label" => __("Home", "talampaya"), "url" => \home_url("/")]];
+
+		$post = Timber::get_post();
+		if ($post) {
+			// Add current page title (no URL for current page)
+			$breadcrumbs[] = [
+				"label" => $post->title(),
+			];
+		}
+
+		return $breadcrumbs;
+	}
+}

--- a/src/theme/src/Inc/Helpers/PaginationHelper.php
+++ b/src/theme/src/Inc/Helpers/PaginationHelper.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Inc\Helpers;
+
+/**
+ * Helper class for pagination logic
+ */
+class PaginationHelper
+{
+	/**
+	 * Get pagination data from a WP_Query
+	 *
+	 * @param \WP_Query $query The WordPress query object
+	 * @param int $posts_per_page Number of posts per page
+	 * @param string $base_url Base URL for pagination links
+	 * @param bool $use_page_format Whether to use /page/N/ format instead of ?paged=N
+	 * @param string $query_param Query parameter name (default: "paged")
+	 * @param string $classes Additional CSS classes for pagination
+	 * @return array|null Pagination data or null if pagination not needed
+	 */
+	public static function getPaginationFromQuery(
+		\WP_Query $query,
+		int $posts_per_page,
+		string $base_url,
+		bool $use_page_format = false,
+		string $query_param = "paged",
+		string $classes = ""
+	): ?array {
+		// Get current page
+		$paged = $query->get("paged") ?: ($query->get("page") ?: 1);
+
+		// Calculate total pages
+		$total_posts = (int) ($query->found_posts ?? 0);
+		$max_pages = (int) ($query->max_num_pages ?? 0);
+		$total_pages =
+			$max_pages > 0
+				? $max_pages
+				: ($total_posts > 0
+					? (int) ceil($total_posts / $posts_per_page)
+					: 0);
+
+		// Only return pagination if there are multiple pages AND we have posts
+		if ($total_pages <= 1 || $total_posts <= 0) {
+			return null;
+		}
+
+		return [
+			"currentPage" => $paged,
+			"totalPages" => $total_pages,
+			"baseUrl" => $base_url,
+			"queryParam" => $query_param,
+			"usePageFormat" => $use_page_format,
+			"classes" => $classes,
+		];
+	}
+
+	/**
+	 * Check if a requested page is valid and redirect if necessary
+	 *
+	 * @param int $requested_page The page number requested
+	 * @param int $total_pages Total number of pages
+	 * @param int $total_posts Total number of posts
+	 * @param string $redirect_url Base URL for redirect
+	 * @param bool $use_page_format Whether to use /page/N/ format
+	 * @return bool True if page is valid, false if redirect was performed
+	 */
+	public static function validateAndRedirect(
+		int $requested_page,
+		int $total_pages,
+		int $total_posts,
+		string $redirect_url,
+		bool $use_page_format = false
+	): bool {
+		// If user is trying to access a page that doesn't exist, redirect to last valid page
+		if ($requested_page > $total_pages && $total_pages > 0 && $total_posts > 0) {
+			if ($use_page_format && $total_pages > 1) {
+				$redirect_url = rtrim($redirect_url, "/") . "/page/" . $total_pages . "/";
+			} else {
+				$redirect_url = add_query_arg("paged", $total_pages, $redirect_url);
+			}
+			\wp_safe_redirect($redirect_url, 301);
+			exit();
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
## Summary

Three small, generic helper additions extracted from the `girbau-wp` fork. No new dependencies, no business-specific code.

### 1. `Inc/Helpers/PaginationHelper.php` (new)

Two static methods that any theme can use to wire pagination without copy-pasting math:

- `getPaginationFromQuery(\WP_Query $query, int $posts_per_page, string $base_url, bool $use_page_format = false, string $query_param = "paged", string $classes = "")` — returns a structured array (`currentPage`, `totalPages`, `baseUrl`, `queryParam`, `usePageFormat`, `classes`) or `null` when pagination isn't needed.
- `validateAndRedirect(int $requested_page, int $total_pages, int $total_posts, string $redirect_url, bool $use_page_format = false)` — 301-redirects to the last valid page when someone asks for a page that no longer exists.

Supports both `?paged=N` and `/page/N/` URL formats.

### 2. `Inc/Helpers/BreadcrumbHelper.php` (new)

Minimal Timber-backed breadcrumb generator (`Home > Current page`). Returns the breadcrumb structure as a plain array so the rendering stays in Twig. Acts as a default template that themes can extend per post type / taxonomy.

### 3. `Inc/Helpers/AcfHelper.php` — bug fix

When a field group is rendered inside a repeater, `talampaya_replace_keys_from_acf_register_fields()` prefixes each subfield key. Any `conditional_logic` rule authored against the original (un-prefixed) name was left orphaned and **silently broken** — ACF couldn't resolve the reference, so the conditional simply never fired.

This PR adds a private `updateConditionalLogicReferences()` that:

1. Builds a `original_name → prefixed_key` map from the just-rewritten subfields.
2. Rewrites every `conditional_logic` rule that references one of the original names.

It's called automatically after the recursive subfield key replacement, so existing field definitions just start working. No API change.

## Test plan

- [ ] Create a repeater with two subfields where one has `conditional_logic` pointing at the other. Register via `talampaya_replace_keys_from_acf_register_fields()`. Confirm the conditional fires in the ACF admin.
- [ ] `PaginationHelper::getPaginationFromQuery()` returns `null` for `total_pages <= 1`, populated array otherwise.
- [ ] `PaginationHelper::validateAndRedirect()` triggers a 301 when asking for `?paged=99` on a 5-page archive.
- [ ] `BreadcrumbHelper::generateBreadcrumbs()` returns 2 items on any single page (Home + current title).

## Notes

The fork also has `MenuHelper`, `StaticPagesHelper`, and several traits, but they all depend on opinionated constants (`THEME_MENUS`, `STATIC_PAGES`) or carry business-specific naming conventions (`SharedModulesFieldsTrait`, `SharedModulesControllerTrait`). Those are not part of this PR — they deserve their own discussion about whether/how to introduce the conventions upstream.

The fork's button-action helpers in `AcfHelper` (`correctButtonConditionalLogic`, `correctButtonConditionalLogicAtGroupLevel`, `correctContentTypeConditionalLogic`) were intentionally left behind because they hard-code field-naming conventions (`button_action`, `button_url`, `button_file`, `content_type`) that aren't universal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)