### PR TITLE
feat(seo): multisite hreflang and sitemap-index aggregation

### DIFF
--- a/src/theme/src/Features/Seo/MultisiteHreflangLinks.php
+++ b/src/theme/src/Features/Seo/MultisiteHreflangLinks.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Features\Seo;
+
+/**
+ * Multisite hreflang generator (no WPML/Polylang required).
+ *
+ * Resolves equivalents across subsites using a stable per-post meta key
+ * (`_protected_page_key` by default), so hreflang alternates keep working
+ * even when editors localize the URL slugs per subsite.
+ *
+ * To wire it up:
+ * - Set the meta key on each "anchor" page that should be cross-linked
+ *   (e.g. `_protected_page_key = "about"`) on every subsite.
+ * - For dynamic CPTs/taxonomies, hook into `talampaya_hreflang_key` or
+ *   `talampaya_hreflang_alternates` to provide the mapping yourself.
+ *
+ * Intentionally conservative: only outputs alternates it can resolve, so a
+ * missing meta key just means no `<link rel="alternate">` is emitted.
+ */
+class MultisiteHreflangLinks
+{
+	/**
+	 * Per-post meta key used to identify the same logical page across subsites.
+	 * Stable even if editors change the per-locale slug.
+	 *
+	 * Override per-request via the `talampaya_hreflang_key` filter.
+	 */
+	private const PROTECTED_PAGE_KEY_META = "_protected_page_key";
+
+	public function __construct()
+	{
+		if (!is_multisite() || is_admin()) {
+			return;
+		}
+
+		add_action("wp_head", [$this, "render"], 5);
+	}
+
+	public function render(): void
+	{
+		if (is_feed() || is_robots() || is_trackback()) {
+			return;
+		}
+
+		$alternates = $this->buildAlternates();
+		if (empty($alternates)) {
+			return;
+		}
+
+		/**
+		 * Filter final hreflang alternates.
+		 *
+		 * @param array<string,string> $alternates Map hreflang => url
+		 */
+		$alternates = apply_filters("talampaya_hreflang_alternates", $alternates);
+		if (empty($alternates) || !is_array($alternates)) {
+			return;
+		}
+
+		foreach ($alternates as $hreflang => $url) {
+			if (!$hreflang || !$url) {
+				continue;
+			}
+
+			printf(
+				"<link rel=\"alternate\" hreflang=\"%s\" href=\"%s\" />\n",
+				esc_attr($hreflang),
+				esc_url($url)
+			);
+		}
+	}
+
+	/**
+	 * @return array<string,string> Map hreflang => url
+	 */
+	private function buildAlternates(): array
+	{
+		$is_front = is_front_page() || is_home();
+		$is_singular = is_singular();
+
+		// Start conservative: expand later if needed (tax archives, CPT archives, etc.).
+		if (!$is_front && !$is_singular) {
+			return [];
+		}
+
+		$current_blog_id = get_current_blog_id();
+		$current_post = get_queried_object();
+		$current_post_type = $current_post instanceof \WP_Post ? $current_post->post_type : null;
+		$page_key = $this->getCurrentProtectedPageKey($current_post);
+
+		$sites = get_sites([
+			"archived" => 0,
+			"deleted" => 0,
+		]);
+
+		$alternates = [];
+
+		foreach ($sites as $site) {
+			$blog_id = (int) $site->blog_id;
+
+			if ($blog_id === $current_blog_id) {
+				$url = $this->getCurrentUrl();
+				$hreflang = $this->localeToHreflang($this->getCurrentSiteLocale());
+			} else {
+				$result = $this->resolveAlternateOnBlog($blog_id, $page_key, $current_post_type);
+				$url = $result["url"] ?? null;
+				$hreflang = $result["hreflang"] ?? null;
+			}
+
+			if (!$url || !$hreflang) {
+				continue;
+			}
+
+			$alternates[$hreflang] = $url;
+		}
+
+		return $alternates;
+	}
+
+	/**
+	 * Returns the site locale for the current blog (not the user locale).
+	 * In WordPress, site language is stored in the WPLANG option.
+	 */
+	private function getCurrentSiteLocale(): string
+	{
+		$wplang = get_option("WPLANG");
+		return is_string($wplang) && $wplang !== "" ? $wplang : "en_US";
+	}
+
+	private function getCurrentUrl(): ?string
+	{
+		if (is_front_page() || is_home()) {
+			return home_url("/");
+		}
+
+		$post = get_queried_object();
+		if ($post instanceof \WP_Post) {
+			$permalink = get_permalink($post);
+			return $permalink ?: null;
+		}
+
+		return null;
+	}
+
+	private function getCurrentProtectedPageKey($queried): ?string
+	{
+		$key = null;
+
+		if ($queried instanceof \WP_Post) {
+			$key = get_post_meta($queried->ID, self::PROTECTED_PAGE_KEY_META, true) ?: null;
+		}
+
+		/**
+		 * Filter the hreflang mapping key for the current request.
+		 *
+		 * @param string|null $key
+		 */
+		$key = apply_filters("talampaya_hreflang_key", $key);
+
+		return is_string($key) && $key !== "" ? $key : null;
+	}
+
+	/**
+	 * @return array{url:?string,hreflang:?string}
+	 */
+	private function resolveAlternateOnBlog(
+		int $blog_id,
+		?string $page_key,
+		?string $current_post_type
+	): array {
+		$current_post = get_queried_object();
+		if (!$current_post instanceof \WP_Post) {
+			return ["url" => null, "hreflang" => null];
+		}
+
+		switch_to_blog($blog_id);
+		try {
+			// IMPORTANT: use the target blog's site language (WPLANG), not the current request locale.
+			$hreflang = $this->localeToHreflang($this->getCurrentSiteLocale());
+
+			if (is_front_page() || is_home()) {
+				return ["url" => home_url("/"), "hreflang" => $hreflang];
+			}
+
+			if ($page_key && $current_post_type) {
+				$alt_post = $this->findPostByProtectedPageKey($page_key, $current_post_type);
+				if ($alt_post instanceof \WP_Post) {
+					$permalink = get_permalink($alt_post);
+					return ["url" => $permalink ?: null, "hreflang" => $hreflang];
+				}
+			}
+
+			return ["url" => null, "hreflang" => $hreflang];
+		} finally {
+			restore_current_blog();
+		}
+	}
+
+	private function findPostByProtectedPageKey(string $key, string $post_type): ?\WP_Post
+	{
+		$posts = get_posts([
+			"post_type" => $post_type,
+			"post_status" => "publish",
+			"numberposts" => 1,
+			"meta_key" => self::PROTECTED_PAGE_KEY_META,
+			"meta_value" => $key,
+			"suppress_filters" => true,
+		]);
+
+		$post = $posts[0] ?? null;
+		return $post instanceof \WP_Post ? $post : null;
+	}
+
+	private function localeToHreflang(string $locale): string
+	{
+		return strtolower(str_replace("_", "-", $locale));
+	}
+}

--- a/src/theme/src/Features/Seo/MultisiteSitemapIndex.php
+++ b/src/theme/src/Features/Seo/MultisiteSitemapIndex.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Features\Seo;
+
+/**
+ * Agrega los sitemaps de los subsitios al sitemap index del sitio principal
+ *
+ * En un WordPress Multisite con subdirectorios, Yoast SEO genera un sitemap
+ * independiente para cada subsitio. Esta clase modifica el sitemap index
+ * del sitio principal para incluir referencias a los sitemaps de todos
+ * los subsitios, facilitando el rastreo por parte de los motores de búsqueda.
+ */
+class MultisiteSitemapIndex
+{
+	public function __construct()
+	{
+		// Solo ejecutar si es multisite
+		if (!is_multisite()) {
+			return;
+		}
+
+		// Agregar sitemaps de subsitios al índice principal
+		add_filter("wpseo_sitemap_index", [$this, "addSubsiteSitemaps"]);
+	}
+
+	/**
+	 * Agrega los sitemaps de los subsitios al sitemap index del sitio principal
+	 *
+	 * @param string $sitemap_index El contenido XML del sitemap index
+	 * @return string El sitemap index modificado con las referencias a los subsitios
+	 */
+	public function addSubsiteSitemaps(string $sitemap_index): string
+	{
+		// Solo ejecutar en el sitio principal
+		if (!is_main_site()) {
+			return $sitemap_index;
+		}
+
+		$subsites = get_sites([
+			//"public" => 1,
+			"archived" => 0,
+			"deleted" => 0,
+		]);
+
+		$external_sitemaps = "";
+		$current_time = date("c");
+
+		foreach ($subsites as $subsite) {
+			if ((int) $subsite->blog_id === get_main_site_id()) {
+				continue;
+			}
+
+			$subsite_url = get_site_url((int) $subsite->blog_id);
+			$sitemap_url = trailingslashit($subsite_url) . "sitemap_index.xml";
+
+			$external_sitemaps .= sprintf(
+				"<sitemap><loc>%s</loc><lastmod>%s</lastmod></sitemap>" . PHP_EOL,
+				esc_url($sitemap_url),
+				$current_time
+			);
+		}
+
+		if (str_contains($sitemap_index, "</sitemapindex>")) {
+			return str_replace(
+				"</sitemapindex>",
+				$external_sitemaps . "</sitemapindex>",
+				$sitemap_index
+			);
+		}
+
+		return $sitemap_index . $external_sitemaps;
+	}
+}

--- a/src/theme/src/bootstrap.php
+++ b/src/theme/src/bootstrap.php
@@ -153,6 +153,15 @@ class Bootstrap
 		if (class_exists("App\\Features\\Permalinks\\CustomPermalinks")) {
 			new \App\Features\Permalinks\CustomPermalinks();
 		}
+
+		// SEO multisite: hreflang + sitemap index aggregation.
+		// Both classes self-deactivate when `is_multisite()` is false.
+		if (class_exists("App\\Features\\Seo\\MultisiteSitemapIndex")) {
+			new \App\Features\Seo\MultisiteSitemapIndex();
+		}
+		if (class_exists("App\\Features\\Seo\\MultisiteHreflangLinks")) {
+			new \App\Features\Seo\MultisiteHreflangLinks();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Two opt-in SEO features for WordPress Multisite installs. Both self-deactivate on single-site (`!is_multisite()` early-return), so dropping them in costs nothing on installs that don't need them.

### `Features/Seo/MultisiteSitemapIndex.php`

Hooks into Yoast SEO's `wpseo_sitemap_index` and, on the main site only, appends a `<sitemap>` entry for every non-main subsite's `sitemap_index.xml`. Lets crawlers discover all per-subsite sitemaps from the network root. No effect on subsites' own sitemaps.

### `Features/Seo/MultisiteHreflangLinks.php`

Outputs `<link rel="alternate" hreflang="...">` tags on the front-end by mapping the current page to its equivalent on each other subsite.

- Mapping driven by a per-post meta key (`_protected_page_key` by default) so editors can keep localized URL slugs without breaking the cross-link.
- For requests where the meta key isn't set, no alternates are emitted (graceful — no broken URLs).
- Two filters for customization:
  - `talampaya_hreflang_key` — per-request override of the mapping key (useful for CPTs/taxonomies that don't use the protected-page-key convention).
  - `talampaya_hreflang_alternates` — final-shape override of the whole `hreflang => url` map.

### Wiring

`bootstrap.php` instantiates both behind `class_exists()` guards, matching the existing pattern used for `CustomPermalinks`. Both classes early-return on single-site, so the only cost on a single-site install is the `class_exists` check.

## Test plan

- [ ] Single-site: install, browse a page, view source — no `<link rel="alternate">` emitted, no errors.
- [ ] Multisite main site: view `/sitemap_index.xml` — subsite sitemap entries are appended.
- [ ] Multisite subsite: view `/sitemap_index.xml` — unchanged.
- [ ] Multisite: on two subsites, create two pages with matching `_protected_page_key` meta, browse one in front-end — `<link rel="alternate">` for the other subsite is emitted with the correct `hreflang` (derived from the target subsite's `WPLANG`).
- [ ] Multisite home: alternates point at each subsite's `home_url("/")`.

## Notes — Permissions framework deferred

The fork also has a Multisite Permissions framework under `Features/Permissions/` (capability mapping, approval workflow, network roles, restrictions, dashboard widgets). It's **not** included here because:

- `Config/PermissionsConfig.php` hardcodes specific CPT slugs (`product_post`, `news_post`, `sector_post`, …).
- `MultisitePermissions.php` (orchestrator) hardcodes business-specific role classes (`ProductManagerRole`, `JobManagerRole`).
- Upstreaming it cleanly requires a design discussion to refactor it into a hook-driven registry (interface-based role registration, CPT permission config via filter).

I can prepare a separate PR with that refactor if the direction is approved — happy to discuss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)